### PR TITLE
Allow zip archives to be opened

### DIFF
--- a/arrownavigation/__init__.py
+++ b/arrownavigation/__init__.py
@@ -4,7 +4,10 @@ from fman.fs import is_dir
 class OpenIfDirectory(DirectoryPaneCommand):
 	def __call__(self):
 		file_under_cursor = self.pane.get_file_under_cursor()
-		if file_under_cursor and is_dir(file_under_cursor):
-			self.pane.set_path(file_under_cursor)
+		if file_under_cursor:
+			if is_dir(file_under_cursor):
+				self.pane.set_path(file_under_cursor)
+			elif file_under_cursor[-4:]==".zip":
+				self.pane.run_command("open")
 	def is_visible(self):
 		return False


### PR DESCRIPTION
Currently works only with `.zip` archives. I couldn't find a way using the current API to more generally check if `file_under_cursor` is  'something that fman can open', which I think would be ideal.